### PR TITLE
:bug: fix: add web-vitals and React in scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19240,6 +19240,11 @@
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
       "dev": true
     },
+    "web-vitals": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
+      "integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.1",
     "react-scripts": "3.4.3",
-    "redux": "^4.0.5"
+    "redux": "^4.0.5",
+    "web-vitals": "^0.2.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import logo from './logo-borgomul-triangle.svg';
 import './App.css';
 


### PR DESCRIPTION
I got error with 

```bash
'React' must be in scope when using JSX
```

 Because React v16 still need to import React into components to use JSX. Fix this with import React explicitly inside `src/App.js`.

```bash
Module not found: Can't resolve 'web-vitals' in '*\borgomul-webapp-js\src'
```

fix this by adding 'web-vitals' by 'npm i web-vitals'.